### PR TITLE
Add a new configuration option 'clone_project_from_master'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ clusterrunner.zip
 repos/
 results/
 slave_results/
+
+# Virtual Environment (virtualenv)
+venv

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -122,12 +122,13 @@ class Git(ProjectType):
 
         # We modify the repo url so the slave clones or fetches from the master directly. This should be faster than
         # cloning/fetching from the original git remote.
-        master_repo_url = 'ssh://{}{}'.format(Configuration['hostname'], self._repo_directory)
-        param_overrides['url'] = master_repo_url  # This causes the slave to clone directly from the master.
+        if Configuration['clone_project_from_master']:
+          master_repo_url = 'ssh://{}{}'.format(Configuration['hostname'], self._repo_directory)
+          param_overrides['url'] = master_repo_url  # This causes the slave to clone directly from the master.
 
-        # The user-specified branch is overwritten with a locally created ref so that slaves working on a job can
-        # continue to fetch the same HEAD, even if the master resets the user-specified branch for another build.
-        param_overrides['branch'] = self._local_ref
+          # The user-specified branch is overwritten with a locally created ref so that slaves working on a job can
+          # continue to fetch the same HEAD, even if the master resets the user-specified branch for another build.
+          param_overrides['branch'] = self._local_ref
 
         return param_overrides
 

--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -82,6 +82,9 @@ class BaseConfigLoader(object):
         # CORS support - a regex to match against allowed API request origins, or None to disable CORS
         conf.set('cors_allowed_origins_regex', None)
 
+        # Clone a project from master (over SSH)
+        conf.set('clone_project_from_master', False)
+
     def configure_postload(self, conf):
         """
         After the clusterrunner.conf file has been loaded, generate the paths which descend from the base_directory
@@ -126,6 +129,7 @@ class BaseConfigLoader(object):
             'eventlog_filename',
             'git_strict_host_key_checking',
             'cors_allowed_origins_regex',
+            'clone_project_from_master'
         ]
 
     def _load_section_from_config_file(self, config, config_filename, section):

--- a/conf/default_clusterrunner.conf
+++ b/conf/default_clusterrunner.conf
@@ -26,6 +26,9 @@
 ## CORS support - a regex to match against allowed API request origins, or None to disable CORS
 # cors_allowed_origins_regex = None
 
+## Clone the project from the master
+# clone_project_from_master = False
+
 [master]
 ## The port the master service will run on
 # port = 43000

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -194,6 +194,7 @@ class TestGit(BaseUnitTestCase):
         self.patch('app.project_type.git.os.path.isfile').return_value = False
         self.patch('app.project_type.git._GitRemoteCommandExecutor')
         Configuration['repo_directory'] = '/repo-directory'
+        Configuration['clone_project_from_master'] = True
 
         git = Git(url='http://original-user-specified-url.test/repo-path/repo-name')
         git.fetch_project()


### PR DESCRIPTION
Hello @dudeche, @ronpepsi, @giannic, 

Please review the following commits I made in branch 'huckphin-gitClone'.

dd82f275cc741a3e9975bc5cbb522155e6063fb2 (2015-05-21 16:19:24 -0700)
Add a new configuration option 'clone_project_from_master'
Useful to allow overrides in case the project does not want
to clone the project from the master and use the original
project parameters.

R=@dudeche
R=@ronpepsi
R=@giannic
