### PR TITLE
Logging improvements - output build number on setup fail so we can use ansible to query the logs

### DIFF
--- a/app/client/build_runner.py
+++ b/app/client/build_runner.py
@@ -62,6 +62,7 @@ class BuildRunner(object):
         except _BuildRunnerError as ex:
             self._logger.error(str(ex))
             self._logger.warning('Script aborted due to error!')
+            self._download_and_extract_results()
             self._cancel_build()
             return False
 

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -278,6 +278,17 @@ class Build(object):
         """
         self._state_machine.trigger(BuildEvent.FAIL, error_msg=failure_reason)
 
+    def mark_setup_failed(self, failure_reason):
+        """
+        Mark a build as failed and set a failure reason. Because setup failures don't have any logs, we put the build_id
+        in the setup_failed file for easier querying of worker logs.
+        :type failure_reason: str
+        """
+        self._state_machine.trigger(BuildEvent.FAIL, error_msg='{} Build Id: {}.'.format(failure_reason, self._build_id))
+        setup_failure_file = os.path.join(self._build_results_dir(), 'setup_failed')
+        app.util.fs.write_file(str(self._build_id), setup_failure_file)
+        self._create_build_artifact()
+
     def _on_enter_error_state(self, event):
         """
         Store an error message for the build and log the failure. This method is triggered by

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -285,7 +285,7 @@ class Build(object):
         :type failure_reason: str
         """
         self._state_machine.trigger(BuildEvent.FAIL, error_msg='{} Build Id: {}.'.format(failure_reason, self._build_id))
-        setup_failure_file = os.path.join(self._build_results_dir(), 'setup_failed')
+        setup_failure_file = os.path.join(self._build_results_dir(), BuildArtifact.SETUP_FAILED_FILE)
         app.util.fs.write_file(str(self._build_id), setup_failure_file)
         self._create_build_artifact()
 

--- a/app/master/build_artifact.py
+++ b/app/master/build_artifact.py
@@ -13,6 +13,7 @@ class BuildArtifact(object):
     COMMAND_FILE = 'clusterrunner_command'
     EXIT_CODE_FILE = 'clusterrunner_exit_code'
     OUTPUT_FILE = 'clusterrunner_console_output'
+    SETUP_FAILED_FILE = 'clusterrunner_setup_failed'
     TIMING_FILE = 'clusterrunner_time'
     ARTIFACT_FILE_NAME = 'results.tar.gz'
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -217,8 +217,7 @@ class ClusterMaster(ClusterService):
         :type slave: Slave
         """
         build = self.get_build(slave.current_build_id)
-        build.cancel()
-        build.mark_failed('Unable to setup build on slave. Failing the build.')
+        build.mark_setup_failed('Unable to setup build on slave.')
         slave.teardown()
 
     def handle_request_for_new_build(self, build_params):

--- a/test/unit/client/test_build_runner.py
+++ b/test/unit/client/test_build_runner.py
@@ -66,8 +66,8 @@ class TestBuildRunner(BaseUnitTestCase):
             expected_log_warning_args=[call('Script aborted due to error!')],
             expected_log_error_args=[call('Build aborted due to error: None')],
         )
-        self.assertFalse(runner._download_and_extract_results.called,
-                         'Client should not have tried to download results')
+        self.assertTrue(runner._download_and_extract_results.called,
+                         'Client should have tried to download results')
 
     def test_runner_should_abort_when_status_is_invalid(self):
         runner, logger, build_id = self._create_build_runner_instance({'build': 'x'})
@@ -88,5 +88,5 @@ class TestBuildRunner(BaseUnitTestCase):
                 ),
             ],
         )
-        self.assertFalse(runner._download_and_extract_results.called,
-                         'Client should not have tried to download results')
+        self.assertTrue(runner._download_and_extract_results.called,
+                         'Client should have tried to download results')

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -247,7 +247,7 @@ class TestGit(BaseUnitTestCase):
                                                                'expected.')
 
     def test_slave_param_overrides_when_get_project_from_master_is_disabled(self):
-        Configuration['get_project_from_master'] = True
+        Configuration['get_project_from_master'] = False
 
         git = Git(url='http://original-user-specified-url.test/repo-path/repo-name')
         actual_overrides = git.slave_param_overrides()


### PR DESCRIPTION
@huckphin @dudeche 
1. Outputs build number to setup_failed
2. It used to be that the client doesn't download the build result on fail. But we want it to, so we can see the logs. So I made it.
3. I broke a unit test on merge, so went ahead and fixed that.
